### PR TITLE
Fix bulkhead typo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10886,7 +10886,7 @@ WorldClock getNow(){}</code></pre>
 If the invocation succeeds then the circuit is back to closed again.</p>
 </div>
 <div class="paragraph">
-<p>You can use <strong>bulkahead</strong> pattern to limit the number of concurrent access to the same resource.
+<p>You can use <strong>bulkhead</strong> pattern to limit the number of concurrent access to the same resource.
 If the operation is synchronous it uses a semaphore approach, if it is asynchronous a thread-pool one.
 When a request cannot be processed <code>BulkheadException</code> is thrown.
 It can be used together with any other fault tolerance annotation.</p>

--- a/examples/quarkus-cheat-sheet/network.adoc
+++ b/examples/quarkus-cheat-sheet/network.adoc
@@ -723,7 +723,7 @@ WorldClock getNow(){}
 If 3 `(4 x 0.75)` failures occur among the rolling window of 4 consecutive invocations then the circuit is opened for 1000 ms and then be back to half open.
 If the invocation succeeds then the circuit is back to closed again.
 
-You can use *bulkahead* pattern to limit the number of concurrent access to the same resource. 
+You can use *bulkhead* pattern to limit the number of concurrent access to the same resource. 
 If the operation is synchronous it uses a semaphore approach, if it is asynchronous a thread-pool one.
 When a request cannot be processed `BulkheadException` is thrown.
 It can be used together with any other fault tolerance annotation. 

--- a/examples/quarkus-cheat-sheet/quarkus-cheat-sheet.html
+++ b/examples/quarkus-cheat-sheet/quarkus-cheat-sheet.html
@@ -8193,7 +8193,7 @@ WorldClock getNow(){}</code></pre>
 </div>
 <p class="">If 3 <code>(4 x 0.75)</code> failures occur among the rolling window of 4 consecutive invocations then the circuit is opened for 1000 ms and then be back to half open.
 If the invocation succeeds then the circuit is back to closed again.</p>
-<p class="">You can use <strong>bulkahead</strong> pattern to limit the number of concurrent access to the same resource.
+<p class="">You can use <strong>bulkhead</strong> pattern to limit the number of concurrent access to the same resource.
 If the operation is synchronous it uses a semaphore approach, if it is asynchronous a thread-pool one.
 When a request cannot be processed <code>BulkheadException</code> is thrown.
 It can be used together with any other fault tolerance annotation.</p>

--- a/examples/quarkus-cheat-sheet/site.html
+++ b/examples/quarkus-cheat-sheet/site.html
@@ -562,7 +562,7 @@ WorldClock getNow(){}</code></pre>
 If the invocation succeeds then the circuit is back to closed again.</p>
 </div>
 <div class="paragraph">
-<p>You can use <strong>bulkahead</strong> pattern to limit the number of concurrent access to the same resource.
+<p>You can use <strong>bulkhead</strong> pattern to limit the number of concurrent access to the same resource.
 If the operation is synchronous it uses a semaphore approach, if it is asynchronous a thread-pool one.
 When a request cannot be processed <code>BulkheadException</code> is thrown.
 It can be used together with any other fault tolerance annotation.</p>
@@ -2805,7 +2805,7 @@ WorldClock getNow(){}</code></pre>
 If the invocation succeeds then the circuit is back to closed again.</p>
 </div>
 <div class="paragraph">
-<p>You can use <strong>bulkahead</strong> pattern to limit the number of concurrent access to the same resource.
+<p>You can use <strong>bulkhead</strong> pattern to limit the number of concurrent access to the same resource.
 If the operation is synchronous it uses a semaphore approach, if it is asynchronous a thread-pool one.
 When a request cannot be processed <code>BulkheadException</code> is thrown.
 It can be used together with any other fault tolerance annotation.</p>


### PR DESCRIPTION
Fix _bulkead_ typo.

Please, rebuild PDF for including the changes.